### PR TITLE
change: split Tags Page by locale

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,6 +7,8 @@ const dateFilter = require('./src/filters/date-filter.js');
 const dateFilterJa = require('./src/filters/date-filter-ja.js');
 const markdownFilter = require('./src/filters/markdown-filter.js');
 const w3DateFilter = require('./src/filters/w3-date-filter.js');
+const enItemFilter = require('./src/filters/lang-en-item-filter.js');
+const jaItemFilter = require('./src/filters/lang-ja-item-filter.js');
 
 // Import transforms
 const htmlMinTransform = require('./src/transforms/html-min-transform.js');
@@ -26,6 +28,8 @@ module.exports = function(config) {
   config.addFilter('dateFilterJa', dateFilterJa);
   config.addFilter('markdownFilter', markdownFilter);
   config.addFilter('w3DateFilter', w3DateFilter);
+  config.addFilter('enItemFilter', enItemFilter);
+  config.addFilter('jaItemFilter', jaItemFilter);
 
   // Layout aliases
   config.addLayoutAlias('home', 'layouts/home.njk');

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -88,7 +88,7 @@
               <ul class="[ nav__list ] [ box-flex align-center pad-left-400 ] [ p-category ]">
                 {% for item in tags %}
                   <li class="tag__item">
-                    {% set tagLink = '/tags/' + item %}
+                    {% set tagLink = '/tags/' + item if locale !== 'ja' else '/ja/tags/' + item %}
                     <a href="{{ tagLink | url }}">{{ item }}</a>
                   </li>
                 {% endfor %}

--- a/src/filters/lang-en-item-filter.js
+++ b/src/filters/lang-en-item-filter.js
@@ -1,0 +1,3 @@
+module.exports = function enItemFilter(items) {
+  return items.filter(item => item.data.locale !== 'ja')
+};

--- a/src/filters/lang-ja-item-filter.js
+++ b/src/filters/lang-ja-item-filter.js
@@ -1,0 +1,3 @@
+module.exports = function jaItemFilter(items) {
+  return items.filter(item => item.data.locale === 'ja')
+};

--- a/src/ja/tags.njk
+++ b/src/ja/tags.njk
@@ -12,19 +12,19 @@ pagination:
     - tagList
     - postFeed
   addAllPagesToCollections: true
-permalink: /tags/{{ tag }}/
+permalink: /ja/tags/{{ tag }}/
 ---
 
 {% extends 'layouts/base.njk' %}
 
 {# Intro content #}
-{% set introHeading %}Posts filed under “{{ tag }}”{% endset %}
+{% set introHeading %}“{{ tag }}”タグの記事一覧{% endset %}
 {% set introHeadingLevel = '2' %}
 
 {# Post list content #}
 {% set postListHeadingLevel = '2' %}
-{% set postListHeading = 'Posts' %}
-{% set postListItems = collections[tag] | enItemFilter %}
+{% set postListHeading = '記事一覧' %}
+{% set postListItems = collections[tag] | jaItemFilter %}
 
 {% block content %}
   <main id="main-content" tabindex="-1">


### PR DESCRIPTION
## Why
want to switch the display of the tag list page according to language, just like the article page.

## Implementation
* split to `/tags/{TAG}` and `/ja/tags/{TAG}` pages
* Added a filter to the collection by locale

Feel free to change the contents of the japanese tag page.